### PR TITLE
Fixed: removed android building error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,8 +5,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.google.gms:google-services:4.3.1'
     }
 }
 


### PR DESCRIPTION
Return to the AndroidX version dependencies in build.gradle. Now is clean to build.